### PR TITLE
Add outputs for AWS Elasticsearch resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,11 @@ Note: There are some type of instances which not support encryption and EBS opti
 | Name | Description |
 |------|-------------|
 | domain\_arn | ARN of the Elasticsearch domain. |
+| domain\_id | Unique identifier for the Elasticsearch domain. |
+| domain\_name | Name of the Elasticsearch domain. |
+| endpoint | Domain-specific endpoint used to submit index, search, and data upload requests. |
+| kibana\_endpoint | Domain-specific endpoint for kibana without https scheme. |
 | tags | A mapping of tags to assign to the resource. |
-
 
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,6 +5,26 @@ output "domain_arn" {
   description = "ARN of the Elasticsearch domain."
 }
 
+output "domain_id" {
+  value       = var.zone_awareness_enabled ? join("", aws_elasticsearch_domain.default.*.domain_id) : join("", aws_elasticsearch_domain.single.*.domain_id)
+  description = "Unique identifier for the Elasticsearch domain."
+}
+
+output "domain_name" {
+  value       = var.zone_awareness_enabled ? join("", aws_elasticsearch_domain.default.*.domain_name) : join("", aws_elasticsearch_domain.single.*.domain_name)
+  description = "Name of the Elasticsearch domain."
+}
+
+output "endpoint" {
+  value       = var.zone_awareness_enabled ? join("", aws_elasticsearch_domain.default.*.endpoint) : join("", aws_elasticsearch_domain.single.*.endpoint)
+  description = "Domain-specific endpoint used to submit index, search, and data upload requests."
+}
+
+output "kibana_endpoint" {
+  value       = var.zone_awareness_enabled ? join("", aws_elasticsearch_domain.default.*.kibana_endpoint) : join("", aws_elasticsearch_domain.single.*.kibana_endpoint)
+  description = "Domain-specific endpoint for kibana without https scheme."
+}
+
 output "tags" {
   value       = module.labels.tags
   description = "A mapping of tags to assign to the resource."


### PR DESCRIPTION
# Description

Add missing outputs for AWS Elasticsearch resources.
Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#attributes-reference
