### PR TITLE
add auto tune support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,6 +156,10 @@ resource "aws_elasticsearch_domain" "default" {
     iops        = var.iops
   }
 
+  auto_tune_options {
+    desired_state = var.auto_tune_desired_state
+  }
+
   cognito_options {
     enabled          = var.cognito_enabled
     user_pool_id     = var.user_pool_id

--- a/variables.tf
+++ b/variables.tf
@@ -396,3 +396,13 @@ variable "managed_policy_arns" {
   description = "Set of exclusive IAM managed policy ARNs to attach to the IAM role"
 }
 
+variable "auto_tune_desired_state" {
+  type        = string
+  default     = "DISABLED"
+  description = "Desired state of Auto-Tune for the domain. Valid values are ENABLED, DISABLED."
+
+  validation {
+    condition     = can(regex("^ENABLED$|^DISABLED$", var.auto_tune_desired_state))
+    error_message = "The value must be one of ENABLED, or DISABLED."
+  }
+}


### PR DESCRIPTION
## what
* Adds support to enable the auto-tuning feature of OpenSearch

## why
* We want to enable this feature and be able to have it reflected in the statefile and plans.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#auto_tune_options

## notes
* was not sure how to update the readme, seems to be automated, happy to do anything to update that if needed.